### PR TITLE
Fix `/v2/guild/upgrades` being matched as `/v2/guild/:id/`

### DIFF
--- a/.changeset/quiet-waves-tell.md
+++ b/.changeset/quiet-waves-tell.md
@@ -1,0 +1,5 @@
+---
+"@gw2api/types": patch
+---
+
+Fix `/v2/guild/upgrades` being matched as `/v2/guild/:id/`

--- a/packages/types/endpoints.ts
+++ b/packages/types/endpoints.ts
@@ -354,6 +354,7 @@ export type AuthenticatedOptions = {
 }
 
 export type OptionsByEndpoint<Endpoint extends string> =
+  Endpoint extends BulkExpandedEndpointUrl<KnownBulkExpandedEndpoint & KnownUnauthorizedEndpoint & KnownLocalizedEndpoint, string | number> ? Options & LocalizedOptions :
   Endpoint extends BulkExpandedEndpointUrl<KnownBulkExpandedEndpoint & KnownAuthenticatedEndpoint & KnownLocalizedEndpoint, string | number> ? Options & AuthenticatedOptions & LocalizedOptions :
   Endpoint extends BulkExpandedEndpointUrl<KnownBulkExpandedEndpoint & KnownLocalizedEndpoint, string | number> ? Options & LocalizedOptions :
   Endpoint extends BulkExpandedEndpointUrl<KnownBulkExpandedEndpoint & KnownAuthenticatedEndpoint, string | number> ? Options & AuthenticatedOptions :


### PR DESCRIPTION
This is just a bandaid, will require a nicer solution in the future...